### PR TITLE
refactor, clean up and break out cli options into function

### DIFF
--- a/ldb.cc
+++ b/ldb.cc
@@ -16,21 +16,16 @@ extern "C" {
 
 #define HISTORY ".ldb_history"
 
+//
+//
+//
 int main(int argc, char** argv)
 {
   string key_start = "";
   string key_end = "~";
   int key_limit = 1000;
 
-  ldb::Options options = ldb::get_cli_options(argc, argv);
-  leveldb::DB* db;
-  leveldb::Status status = leveldb::DB::Open(options, options.path, &db);
-
-  if (false == status.ok()) {
-    cerr << "Unable to open/create database './testdb'" << endl;
-    cerr << status.ToString() << endl;
-    return -1;
-  }
+  leveldb::DB* db = ldb::create_database(argc, argv);
 
   linenoiseSetCompletionCallback(ldb::auto_completion);
   linenoiseHistoryLoad(HISTORY);
@@ -92,8 +87,24 @@ int main(int argc, char** argv)
 
     free(line);
   }
+}
 
-   delete db;
+//
+//
+//
+leveldb::DB* ldb::create_database(int argc, char** argv)
+{
+  leveldb::DB* db;
+  ldb::Options options = ldb::get_cli_options(argc, argv);
+  leveldb::Status status = leveldb::DB::Open(options, options.path, &db);
+
+  if (false == status.ok()) {
+    cerr << "Unable to open/create database " << options.path << endl;
+    cerr << status.ToString() << endl;
+    exit(1);
+  }
+
+  return db;
 }
 
 //

--- a/ldb.h
+++ b/ldb.h
@@ -46,6 +46,8 @@ namespace ldb {
 
   vector<string> key_cache;
 
+  leveldb::DB* create_database(int argc, char** argv);
+
   void put_value(leveldb::DB* db, command cmd);
   void get_value(leveldb::DB* db, command cmd);
   void range(leveldb::DB *db, string key_start, string key_end,


### PR DESCRIPTION
Sorry about the diff. It's hard to see what happened because I got rid of indentation and at the same time reordered functions so the order in .h and .cc match. Probably easier if you just check ldb.h and ldb.cc manually.

Main goal is to try and keep the main() function super clean and start breaking out into functions. The functions can more easily be extracted into separate files later on. So should be easier to do https://github.com/hij1nx/ldb/issues/4
