### PR TITLE
add --version argument

### DIFF
--- a/ldb.h
+++ b/ldb.h
@@ -11,6 +11,8 @@
 #include <getopt.h>
 #include <sys/ioctl.h>
 
+#define LDB_VERSION "0.0.1"
+
 extern "C" {
   #include "deps/linenoise/linenoise.h"
 }


### PR DESCRIPTION
also took the liberty to:
- move out all command line options into one function (main is getting big)
- fixed some return values when an error has occured
- removed cleanup of the db completely since the process exits anyway
