### PR TITLE
Only print JSON in interactive mode

### DIFF
--- a/ldb.cc
+++ b/ldb.cc
@@ -28,9 +28,9 @@ int ldb::key_limit = 1000;
 leveldb::DB* ldb::db;
 
 //
-// try to print JSON
+// don't try to print JSON
 //
-int ldb::json = 2;
+int ldb::json = 0;
 
 //
 // colors
@@ -121,6 +121,8 @@ int main(int argc, const char** argv)
   }
 
   if (interactive) {
+    // try to print JSON
+    ldb::json = 2;
     ldb::startREPL();
     return 0;
   }
@@ -164,4 +166,3 @@ int main(int argc, const char** argv)
 
   return 0;
 }
-


### PR DESCRIPTION
When retrieving JSON values for a shell script ldb pretty formats the output and adds colors. This is a problem when using ldb non-interactively in a shell script or whatever.
![screen shot 2018-09-18 at 9 04 46 am](https://user-images.githubusercontent.com/3004481/45689652-86398980-bb22-11e8-82ff-4d9efaad5617.png)

This changes the behavior to only output JSON in interactive mode.
![screen shot 2018-09-18 at 9 08 49 am](https://user-images.githubusercontent.com/3004481/45689708-a701df00-bb22-11e8-808f-80dd87823b87.png)
